### PR TITLE
Environment variables for AWS credentials and bucket name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,9 @@ pipeline {
 
         stage('archiving artifacts into AWS s3') {
             steps {
-                withAWS(region:'us-east-1',credentials:'aws-mo') {
-                    s3Delete(bucket:'cc-case-management-mo-0445', path:'/')
-                    s3Upload(bucket:"cc-case-management-mo-0445", workingDir:'build/', includePathPattern:'**/*');
+                withAWS(region:'us-east-1',credentials:$PIPELINE_CREDENTIAL_NAME) {
+                    s3Delete(bucket:$FRONTEND_BUCKET_NAME, path:'/')
+                    s3Upload(bucket:$FRONTEND_BUCKET_NAME, workingDir:'build/', includePathPattern:'**/*');
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
 
         stage('archiving artifacts into AWS s3') {
             steps {
-                withAWS(region:'us-east-1',credentials:env.PIPELINE_CREDENTIAL_NAME) {
+                withAWS(region:'us-east-1',credentials:'aws-mo') {
                     s3Delete(bucket:env.FRONTEND_BUCKET_NAME, path:'/')
                     s3Upload(bucket:env.FRONTEND_BUCKET_NAME, workingDir:'build/', includePathPattern:'**/*');
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
 
         stage('archiving artifacts into AWS s3') {
             steps {
-                withAWS(region:'us-east-1',credentials:'aws-mo') {
+                withAWS(region:'us-east-1',credentials:env.PIPELINE_CREDENTIAL_NAME) {
                     s3Delete(bucket:env.FRONTEND_BUCKET_NAME, path:'/')
                     s3Upload(bucket:env.FRONTEND_BUCKET_NAME, workingDir:'build/', includePathPattern:'**/*');
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,9 @@ pipeline {
 
         stage('archiving artifacts into AWS s3') {
             steps {
-                withAWS(region:'us-east-1',credentials:'exampleuser-creds-id') {
-                    s3Delete(bucket:'cc-case-management', path:'/')
-                    s3Upload(bucket:"cc-case-management", workingDir:'build/', includePathPattern:'**/*');
+                withAWS(region:'us-east-1',credentials:'aws-mo') {
+                    s3Delete(bucket:'cc-case-management-raza', path:'/')
+                    s3Upload(bucket:"cc-case-management-raza", workingDir:'build/', includePathPattern:'**/*');
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,8 @@ pipeline {
         stage('archiving artifacts into AWS s3') {
             steps {
                 withAWS(region:'us-east-1',credentials:'aws-mo') {
-                    s3Delete(bucket:'cc-case-management-raza', path:'/')
-                    s3Upload(bucket:"cc-case-management-raza", workingDir:'build/', includePathPattern:'**/*');
+                    s3Delete(bucket:'cc-case-management-mo-0445', path:'/')
+                    s3Upload(bucket:"cc-case-management-mo-0445", workingDir:'build/', includePathPattern:'**/*');
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
 
         stage('archiving artifacts into AWS s3') {
             steps {
-                withAWS(region:'us-east-1',credentials:'aws-mo') {
+                withAWS(region:'us-east-1',credentials:'exampleuser-creds-id') {
                     s3Delete(bucket:'cc-case-management', path:'/')
                     s3Upload(bucket:"cc-case-management", workingDir:'build/', includePathPattern:'**/*');
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,9 @@ pipeline {
 
         stage('archiving artifacts into AWS s3') {
             steps {
-                withAWS(region:'us-east-1',credentials:$PIPELINE_CREDENTIAL_NAME) {
-                    s3Delete(bucket:$FRONTEND_BUCKET_NAME, path:'/')
-                    s3Upload(bucket:$FRONTEND_BUCKET_NAME, workingDir:'build/', includePathPattern:'**/*');
+                withAWS(region:'us-east-1',credentials:env.PIPELINE_CREDENTIAL_NAME) {
+                    s3Delete(bucket:env.FRONTEND_BUCKET_NAME, path:'/')
+                    s3Upload(bucket:env.FRONTEND_BUCKET_NAME, workingDir:'build/', includePathPattern:'**/*');
                 }
             }
         }


### PR DESCRIPTION
#### PR Classification
This pull request is a code cleanup and security enhancement, updating the AWS credentials and bucket name used in the Jenkinsfile.

#### PR Summary
The pull request updates the 'archiving artifacts into AWS s3' stage of the Jenkinsfile to use environment variables for AWS credentials and bucket name, improving flexibility, security, and configuration management.
- Jenkinsfile: Replaced hardcoded AWS credentials 'aws-mo' with a reference to an environment variable `PIPELINE_CREDENTIAL_NAME`.
- Jenkinsfile: Replaced hardcoded bucket name 'cc-case-management' with a reference to an environment variable `FRONTEND_BUCKET_NAME`.
- Jenkinsfile: Updated `s3Delete` and `s3Upload` commands to use these new environment variables.
